### PR TITLE
feat: add typed futures contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "pragma-common"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pragma-common"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 categories = ["finance", "api-bindings"]

--- a/schema/entries.proto
+++ b/schema/entries.proto
@@ -51,6 +51,41 @@ message Pair {
   string quote = 2;
 }
 
+enum FuturesMonth {
+  FUTURES_MONTH_UNSPECIFIED = 0;
+  FUTURES_MONTH_JANUARY = 1;
+  FUTURES_MONTH_FEBRUARY = 2;
+  FUTURES_MONTH_MARCH = 3;
+  FUTURES_MONTH_APRIL = 4;
+  FUTURES_MONTH_MAY = 5;
+  FUTURES_MONTH_JUNE = 6;
+  FUTURES_MONTH_JULY = 7;
+  FUTURES_MONTH_AUGUST = 8;
+  FUTURES_MONTH_SEPTEMBER = 9;
+  FUTURES_MONTH_OCTOBER = 10;
+  FUTURES_MONTH_NOVEMBER = 11;
+  FUTURES_MONTH_DECEMBER = 12;
+}
+
+enum FuturesYearFormat {
+  FUTURES_YEAR_FORMAT_UNSPECIFIED = 0;
+  FUTURES_YEAR_FORMAT_ONE_DIGIT = 1;
+  FUTURES_YEAR_FORMAT_TWO_DIGIT = 2;
+}
+
+message FuturesContract {
+  string root = 1;
+  FuturesMonth month = 2;
+  uint32 year = 3;
+  FuturesYearFormat yearFormat = 4;
+}
+
+message Contract {
+  oneof value {
+    FuturesContract futures = 1;
+  }
+}
+
 message BidOrAsk {
   double price = 1;
   double quantity = 2;
@@ -140,6 +175,7 @@ message PositionEntry {
   TradeSide side = 6;
   double notional_in_usd = 7; 
   double size = 8; 
+  Contract contract = 9;
 }
 
 message GlobalExposureEntry {

--- a/schema/entries.proto
+++ b/schema/entries.proto
@@ -173,7 +173,8 @@ message PositionEntry {
   int64 timestampMs = 4;
   int64 receivedTimestampMs = 5;
   TradeSide side = 6;
-  double notional_in_usd = 7; 
+  reserved 7;
+  reserved "notional_in_usd";
   double size = 8; 
   Contract contract = 9;
 }

--- a/schema/entries.proto
+++ b/schema/entries.proto
@@ -67,17 +67,10 @@ enum FuturesMonth {
   FUTURES_MONTH_DECEMBER = 12;
 }
 
-enum FuturesYearFormat {
-  FUTURES_YEAR_FORMAT_UNSPECIFIED = 0;
-  FUTURES_YEAR_FORMAT_ONE_DIGIT = 1;
-  FUTURES_YEAR_FORMAT_TWO_DIGIT = 2;
-}
-
 message FuturesContract {
   string root = 1;
   FuturesMonth month = 2;
   uint32 year = 3;
-  FuturesYearFormat yearFormat = 4;
 }
 
 message Contract {

--- a/schema/entries.proto
+++ b/schema/entries.proto
@@ -184,4 +184,5 @@ message GlobalExposureEntry {
   string asset = 3;
   double gross_position_size = 4; 
   double net_position_size = 5; 
+  Contract contract = 6;
 }

--- a/src/contract/builder.rs
+++ b/src/contract/builder.rs
@@ -56,22 +56,25 @@ impl<'a> FuturesContractBuilder<'a> {
 }
 
 fn split_last_char(value: &str) -> Result<(&str, char), FuturesContractParseError> {
-    value
-        .char_indices()
-        .last()
-        .map(|(index, character)| (&value[..index], character))
+    let mut chars = value.chars();
+    chars
+        .next_back()
+        .map(|character| (chars.as_str(), character))
         .ok_or(FuturesContractParseError::MissingMonthCode)
 }
 
 fn split_raw_contract_symbol(
     raw_symbol: &str,
 ) -> Result<(&str, char, &str), FuturesContractParseError> {
-    let (month_pos, month_char) = raw_symbol
-        .char_indices()
-        .rfind(|(_, c)| c.is_ascii_alphabetic())
+    let bytes = raw_symbol.as_bytes();
+    let month_pos = bytes
+        .iter()
+        .rposition(|byte| byte.is_ascii_alphabetic())
         .ok_or(FuturesContractParseError::MissingMonthCode)?;
-    let (root, month_and_year) = raw_symbol.split_at(month_pos);
-    let (_, year_str) = month_and_year.split_at(month_char.len_utf8());
+
+    let root = &raw_symbol[..month_pos];
+    let month_char = bytes[month_pos] as char;
+    let year_str = &raw_symbol[month_pos + 1..];
 
     if year_str.is_empty() {
         return Err(FuturesContractParseError::MissingYear);
@@ -84,15 +87,23 @@ fn split_raw_contract_symbol(
 }
 
 fn normalize_year(year_str: &str) -> Result<u16, FuturesContractParseError> {
+    let current_year = chrono::Utc::now().date_naive().year();
+    let current_year = u16::try_from(current_year)
+        .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
+
+    normalize_year_for_current_year(year_str, current_year)
+}
+
+fn normalize_year_for_current_year(
+    year_str: &str,
+    current_year: u16,
+) -> Result<u16, FuturesContractParseError> {
     let year_short: u16 = year_str
         .parse()
         .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
 
     match year_str.len() {
         1 => {
-            let current_year = chrono::Utc::now().date_naive().year();
-            let current_year = u16::try_from(current_year)
-                .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
             let decade = (current_year / 10) * 10;
             let mut full_year = decade + year_short;
             if full_year < current_year {
@@ -102,5 +113,27 @@ fn normalize_year(year_str: &str) -> Result<u16, FuturesContractParseError> {
         }
         2 => Ok(2000 + year_short),
         _ => Err(FuturesContractParseError::InvalidYear(year_str.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::normalize_year_for_current_year;
+
+    #[rstest]
+    #[case("6", 2026, 2026)]
+    #[case("5", 2026, 2035)]
+    #[case("0", 2029, 2030)]
+    fn one_digit_years_never_normalize_to_the_past(
+        #[case] year: &str,
+        #[case] current_year: u16,
+        #[case] expected: u16,
+    ) {
+        assert_eq!(
+            normalize_year_for_current_year(year, current_year).unwrap(),
+            expected
+        );
     }
 }

--- a/src/contract/builder.rs
+++ b/src/contract/builder.rs
@@ -1,0 +1,107 @@
+use chrono::Datelike;
+
+use super::{FuturesContract, FuturesContractParseError, FuturesMonth, FuturesRoot, YearFormat};
+
+#[derive(Debug, Clone, Copy)]
+pub struct FuturesContractBuilder<'a> {
+    raw_symbol: &'a str,
+}
+
+impl<'a> FuturesContractBuilder<'a> {
+    pub const fn raw(raw_symbol: &'a str) -> Self {
+        Self { raw_symbol }
+    }
+
+    /// Parse an ACTIV-format contract string: `ROOT/YYMONTHCODE` (e.g. `GC/26M`).
+    pub fn activ(activ_symbol: &str) -> Result<FuturesContract, FuturesContractParseError> {
+        let (root, year_month) = activ_symbol
+            .split_once('/')
+            .ok_or_else(|| FuturesContractParseError::InvalidRoot(activ_symbol.to_string()))?;
+
+        let root = root.trim().to_ascii_uppercase();
+        if root.is_empty() {
+            return Err(FuturesContractParseError::InvalidRoot(
+                activ_symbol.to_string(),
+            ));
+        }
+        if year_month.len() < 2 {
+            return Err(FuturesContractParseError::MissingMonthCode);
+        }
+
+        let month_char = year_month
+            .chars()
+            .last()
+            .ok_or(FuturesContractParseError::MissingMonthCode)?;
+        let year_str = &year_month[..year_month.len() - 1];
+
+        let root = FuturesRoot::new(&root)?;
+        let month = FuturesMonth::from_code(month_char)
+            .ok_or(FuturesContractParseError::InvalidMonthCode(month_char))?;
+        let (year, year_format) = normalize_year(year_str)?;
+
+        Ok(FuturesContract {
+            root,
+            month,
+            year,
+            year_format,
+        })
+    }
+
+    pub fn build(self) -> Result<FuturesContract, FuturesContractParseError> {
+        let normalized = self.raw_symbol.trim().to_ascii_uppercase();
+        if normalized.is_empty() {
+            return Err(FuturesContractParseError::Empty);
+        }
+
+        let month_pos = normalized
+            .rfind(|c: char| c.is_ascii_alphabetic())
+            .ok_or(FuturesContractParseError::MissingMonthCode)?;
+        let root = &normalized[..month_pos];
+        let month_char = normalized
+            .chars()
+            .nth(month_pos)
+            .ok_or(FuturesContractParseError::MissingMonthCode)?;
+        let year_str = &normalized[month_pos + 1..];
+
+        if year_str.is_empty() {
+            return Err(FuturesContractParseError::MissingYear);
+        }
+        if !year_str.chars().all(|c| c.is_ascii_digit()) {
+            return Err(FuturesContractParseError::InvalidYear(year_str.to_string()));
+        }
+
+        let root = FuturesRoot::new(root)?;
+        let month = FuturesMonth::from_code(month_char)
+            .ok_or(FuturesContractParseError::InvalidMonthCode(month_char))?;
+        let (year, year_format) = normalize_year(year_str)?;
+
+        Ok(FuturesContract {
+            root,
+            month,
+            year,
+            year_format,
+        })
+    }
+}
+
+fn normalize_year(year_str: &str) -> Result<(u16, YearFormat), FuturesContractParseError> {
+    let year_short: u16 = year_str
+        .parse()
+        .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
+
+    match year_str.len() {
+        1 => {
+            let current_year = chrono::Utc::now().date_naive().year();
+            let current_year = u16::try_from(current_year)
+                .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
+            let decade = (current_year / 10) * 10;
+            let mut full_year = decade + year_short;
+            if full_year + 1 < current_year {
+                full_year += 10;
+            }
+            Ok((full_year, YearFormat::OneDigit))
+        }
+        2 => Ok((2000 + year_short, YearFormat::TwoDigit)),
+        _ => Err(FuturesContractParseError::InvalidYear(year_str.to_string())),
+    }
+}

--- a/src/contract/builder.rs
+++ b/src/contract/builder.rs
@@ -18,7 +18,7 @@ impl<'a> FuturesContractBuilder<'a> {
             .split_once('/')
             .ok_or_else(|| FuturesContractParseError::InvalidRoot(activ_symbol.to_string()))?;
 
-        let root = root.trim().to_ascii_uppercase();
+        let root = root.trim();
         if root.is_empty() {
             return Err(FuturesContractParseError::InvalidRoot(
                 activ_symbol.to_string(),
@@ -28,42 +28,7 @@ impl<'a> FuturesContractBuilder<'a> {
             return Err(FuturesContractParseError::MissingMonthCode);
         }
 
-        let month_char = year_month
-            .chars()
-            .last()
-            .ok_or(FuturesContractParseError::MissingMonthCode)?;
-        let year_str = &year_month[..year_month.len() - 1];
-
-        let root = FuturesRoot::new(&root)?;
-        let month = FuturesMonth::from_code(month_char)
-            .ok_or(FuturesContractParseError::InvalidMonthCode(month_char))?;
-        let year = normalize_year(year_str)?;
-
-        Ok(FuturesContract { root, month, year })
-    }
-
-    pub fn build(self) -> Result<FuturesContract, FuturesContractParseError> {
-        let normalized = self.raw_symbol.trim().to_ascii_uppercase();
-        if normalized.is_empty() {
-            return Err(FuturesContractParseError::Empty);
-        }
-
-        let month_pos = normalized
-            .rfind(|c: char| c.is_ascii_alphabetic())
-            .ok_or(FuturesContractParseError::MissingMonthCode)?;
-        let root = &normalized[..month_pos];
-        let month_char = normalized
-            .chars()
-            .nth(month_pos)
-            .ok_or(FuturesContractParseError::MissingMonthCode)?;
-        let year_str = &normalized[month_pos + 1..];
-
-        if year_str.is_empty() {
-            return Err(FuturesContractParseError::MissingYear);
-        }
-        if !year_str.chars().all(|c| c.is_ascii_digit()) {
-            return Err(FuturesContractParseError::InvalidYear(year_str.to_string()));
-        }
+        let (year_str, month_char) = split_last_char(year_month.trim())?;
 
         let root = FuturesRoot::new(root)?;
         let month = FuturesMonth::from_code(month_char)
@@ -72,6 +37,50 @@ impl<'a> FuturesContractBuilder<'a> {
 
         Ok(FuturesContract { root, month, year })
     }
+
+    pub fn build(self) -> Result<FuturesContract, FuturesContractParseError> {
+        let raw_symbol = self.raw_symbol.trim();
+        if raw_symbol.is_empty() {
+            return Err(FuturesContractParseError::Empty);
+        }
+
+        let (root, month_char, year_str) = split_raw_contract_symbol(raw_symbol)?;
+
+        let root = FuturesRoot::new(root)?;
+        let month = FuturesMonth::from_code(month_char)
+            .ok_or(FuturesContractParseError::InvalidMonthCode(month_char))?;
+        let year = normalize_year(year_str)?;
+
+        Ok(FuturesContract { root, month, year })
+    }
+}
+
+fn split_last_char(value: &str) -> Result<(&str, char), FuturesContractParseError> {
+    value
+        .char_indices()
+        .last()
+        .map(|(index, character)| (&value[..index], character))
+        .ok_or(FuturesContractParseError::MissingMonthCode)
+}
+
+fn split_raw_contract_symbol(
+    raw_symbol: &str,
+) -> Result<(&str, char, &str), FuturesContractParseError> {
+    let (month_pos, month_char) = raw_symbol
+        .char_indices()
+        .rfind(|(_, c)| c.is_ascii_alphabetic())
+        .ok_or(FuturesContractParseError::MissingMonthCode)?;
+    let (root, month_and_year) = raw_symbol.split_at(month_pos);
+    let (_, year_str) = month_and_year.split_at(month_char.len_utf8());
+
+    if year_str.is_empty() {
+        return Err(FuturesContractParseError::MissingYear);
+    }
+    if !year_str.bytes().all(|c| c.is_ascii_digit()) {
+        return Err(FuturesContractParseError::InvalidYear(year_str.to_string()));
+    }
+
+    Ok((root, month_char, year_str))
 }
 
 fn normalize_year(year_str: &str) -> Result<u16, FuturesContractParseError> {
@@ -86,7 +95,7 @@ fn normalize_year(year_str: &str) -> Result<u16, FuturesContractParseError> {
                 .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
             let decade = (current_year / 10) * 10;
             let mut full_year = decade + year_short;
-            if full_year + 1 < current_year {
+            if full_year < current_year {
                 full_year += 10;
             }
             Ok(full_year)

--- a/src/contract/builder.rs
+++ b/src/contract/builder.rs
@@ -1,6 +1,6 @@
 use chrono::Datelike;
 
-use super::{FuturesContract, FuturesContractParseError, FuturesMonth, FuturesRoot, YearFormat};
+use super::{FuturesContract, FuturesContractParseError, FuturesMonth, FuturesRoot};
 
 #[derive(Debug, Clone, Copy)]
 pub struct FuturesContractBuilder<'a> {
@@ -37,14 +37,9 @@ impl<'a> FuturesContractBuilder<'a> {
         let root = FuturesRoot::new(&root)?;
         let month = FuturesMonth::from_code(month_char)
             .ok_or(FuturesContractParseError::InvalidMonthCode(month_char))?;
-        let (year, year_format) = normalize_year(year_str)?;
+        let year = normalize_year(year_str)?;
 
-        Ok(FuturesContract {
-            root,
-            month,
-            year,
-            year_format,
-        })
+        Ok(FuturesContract { root, month, year })
     }
 
     pub fn build(self) -> Result<FuturesContract, FuturesContractParseError> {
@@ -73,18 +68,13 @@ impl<'a> FuturesContractBuilder<'a> {
         let root = FuturesRoot::new(root)?;
         let month = FuturesMonth::from_code(month_char)
             .ok_or(FuturesContractParseError::InvalidMonthCode(month_char))?;
-        let (year, year_format) = normalize_year(year_str)?;
+        let year = normalize_year(year_str)?;
 
-        Ok(FuturesContract {
-            root,
-            month,
-            year,
-            year_format,
-        })
+        Ok(FuturesContract { root, month, year })
     }
 }
 
-fn normalize_year(year_str: &str) -> Result<(u16, YearFormat), FuturesContractParseError> {
+fn normalize_year(year_str: &str) -> Result<u16, FuturesContractParseError> {
     let year_short: u16 = year_str
         .parse()
         .map_err(|_| FuturesContractParseError::InvalidYear(year_str.to_string()))?;
@@ -99,9 +89,9 @@ fn normalize_year(year_str: &str) -> Result<(u16, YearFormat), FuturesContractPa
             if full_year + 1 < current_year {
                 full_year += 10;
             }
-            Ok((full_year, YearFormat::OneDigit))
+            Ok(full_year)
         }
-        2 => Ok((2000 + year_short, YearFormat::TwoDigit)),
+        2 => Ok(2000 + year_short),
         _ => Err(FuturesContractParseError::InvalidYear(year_str.to_string())),
     }
 }

--- a/src/contract/errors.rs
+++ b/src/contract/errors.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum FuturesContractParseError {
+    #[error("futures contract symbol is empty")]
+    Empty,
+    #[error("futures contract symbol is missing a month code")]
+    MissingMonthCode,
+    #[error("futures contract root is invalid: {0}")]
+    InvalidRoot(String),
+    #[error("invalid futures month code: {0}")]
+    InvalidMonthCode(char),
+    #[error("futures contract symbol is missing a year suffix")]
+    MissingYear,
+    #[error("invalid futures year suffix: {0}")]
+    InvalidYear(String),
+    #[error(
+        "futures contract {contract} is too far in the past for reference date {reference_date}"
+    )]
+    TooFarInPast {
+        contract: String,
+        reference_date: String,
+    },
+    #[error(
+        "futures contract {contract} is too far in the future for reference date {reference_date}"
+    )]
+    TooFarInFuture {
+        contract: String,
+        reference_date: String,
+    },
+}

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -78,6 +78,13 @@ mod tests {
     }
 
     #[test]
+    fn contract_exposes_contract_month_yyyymm() {
+        let contract = Contract::from_raw_symbol("CLM6").unwrap();
+
+        assert_eq!(contract.contract_month_yyyymm(), "202606");
+    }
+
+    #[test]
     fn contract_validation_accepts_reasonable_reference_date() {
         let contract = FuturesContractBuilder::raw("PLJ6").build().unwrap();
         let reference_date = NaiveDate::from_ymd_opt(2026, 3, 24).unwrap();

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -36,6 +36,14 @@ mod tests {
         assert_eq!(contract.to_string(), display);
     }
 
+    #[test]
+    fn one_digit_year_normalizes_to_current_or_next_decade() {
+        let contract = FuturesContractBuilder::raw("CLZ5").build().unwrap();
+
+        assert_eq!(contract.year, 2035);
+        assert_eq!(contract.to_string(), "CLZ35");
+    }
+
     #[rstest]
     #[case("GC", FuturesContractParseError::MissingYear)]
     #[case("6", FuturesContractParseError::MissingMonthCode)]

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -1,0 +1,115 @@
+mod builder;
+mod errors;
+#[cfg(feature = "proto")]
+mod proto;
+mod types;
+
+pub use builder::FuturesContractBuilder;
+pub use errors::FuturesContractParseError;
+pub use types::{Contract, FuturesContract, FuturesMonth, FuturesRoot, YearFormat};
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case("plj6", "PL", FuturesMonth::April, 2026, "PLJ6")]
+    #[case("NGK26", "NG", FuturesMonth::May, 2026, "NGK26")]
+    #[case("RTYM6", "RTY", FuturesMonth::June, 2026, "RTYM6")]
+    #[case("6EZ6", "6E", FuturesMonth::December, 2026, "6EZ6")]
+    #[case("ABCJ6", "ABC", FuturesMonth::April, 2026, "ABCJ6")]
+    fn parses_supported_raw_contracts(
+        #[case] raw: &str,
+        #[case] root: &str,
+        #[case] month: FuturesMonth,
+        #[case] year: u16,
+        #[case] display: &str,
+    ) {
+        let contract = FuturesContractBuilder::raw(raw).build().unwrap();
+
+        assert_eq!(contract.root, FuturesRoot::new(root).unwrap());
+        assert_eq!(contract.month, month);
+        assert_eq!(contract.year, year);
+        assert_eq!(contract.to_string(), display);
+    }
+
+    #[rstest]
+    #[case("GC", FuturesContractParseError::MissingYear)]
+    #[case("6", FuturesContractParseError::MissingMonthCode)]
+    #[case("GCA6", FuturesContractParseError::InvalidMonthCode('A'))]
+    #[case("P.J6", FuturesContractParseError::InvalidRoot("P.".to_string()))]
+    #[case("PLA6", FuturesContractParseError::InvalidMonthCode('A'))]
+    #[case("PLJ260", FuturesContractParseError::InvalidYear("260".to_string()))]
+    fn rejects_invalid_contracts(#[case] raw: &str, #[case] expected: FuturesContractParseError) {
+        let error = FuturesContractBuilder::raw(raw).build().unwrap_err();
+
+        match (error, expected) {
+            (
+                FuturesContractParseError::InvalidYear(actual),
+                FuturesContractParseError::InvalidYear(expected),
+            ) => assert_eq!(actual, expected),
+            (
+                FuturesContractParseError::InvalidRoot(actual),
+                FuturesContractParseError::InvalidRoot(expected),
+            ) => assert_eq!(actual, expected),
+            (actual, expected) => assert_eq!(actual, expected),
+        }
+    }
+
+    #[test]
+    fn parses_activ_contracts() {
+        let contract = FuturesContractBuilder::activ("GC/26M").unwrap();
+
+        assert_eq!(contract.root, FuturesRoot::new("GC").unwrap());
+        assert_eq!(contract.month, FuturesMonth::June);
+        assert_eq!(contract.year, 2026);
+        assert_eq!(contract.raw_symbol(), "GCM26");
+    }
+
+    #[test]
+    fn contract_enum_exposes_raw_symbol() {
+        let contract = Contract::from_raw_symbol("CLK6").unwrap();
+
+        assert_eq!(contract.raw_symbol(), "CLK6");
+        assert_eq!(contract.to_string(), "CLK6");
+    }
+
+    #[test]
+    fn contract_validation_accepts_reasonable_reference_date() {
+        let contract = FuturesContractBuilder::raw("PLJ6").build().unwrap();
+        let reference_date = NaiveDate::from_ymd_opt(2026, 3, 24).unwrap();
+
+        assert_eq!(contract.validate_against_date(reference_date), Ok(()));
+    }
+
+    #[test]
+    fn contract_validation_rejects_contracts_too_far_in_past() {
+        let contract = FuturesContractBuilder::raw("PLG26").build().unwrap();
+        let reference_date = NaiveDate::from_ymd_opt(2026, 3, 24).unwrap();
+
+        assert_eq!(
+            contract.validate_against_date(reference_date),
+            Err(FuturesContractParseError::TooFarInPast {
+                contract: "PLG26".to_string(),
+                reference_date: reference_date.to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn contract_validation_rejects_contracts_too_far_in_future() {
+        let contract = FuturesContractBuilder::raw("PLJ27").build().unwrap();
+        let reference_date = NaiveDate::from_ymd_opt(2026, 3, 24).unwrap();
+
+        assert_eq!(
+            contract.validate_against_date(reference_date),
+            Err(FuturesContractParseError::TooFarInFuture {
+                contract: "PLJ27".to_string(),
+                reference_date: reference_date.to_string(),
+            })
+        );
+    }
+}

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -6,7 +6,7 @@ mod types;
 
 pub use builder::FuturesContractBuilder;
 pub use errors::FuturesContractParseError;
-pub use types::{Contract, FuturesContract, FuturesMonth, FuturesRoot, YearFormat};
+pub use types::{Contract, FuturesContract, FuturesMonth, FuturesRoot};
 
 #[cfg(test)]
 mod tests {
@@ -16,11 +16,11 @@ mod tests {
     use super::*;
 
     #[rstest]
-    #[case("plj6", "PL", FuturesMonth::April, 2026, "PLJ6")]
+    #[case("plj6", "PL", FuturesMonth::April, 2026, "PLJ26")]
     #[case("NGK26", "NG", FuturesMonth::May, 2026, "NGK26")]
-    #[case("RTYM6", "RTY", FuturesMonth::June, 2026, "RTYM6")]
-    #[case("6EZ6", "6E", FuturesMonth::December, 2026, "6EZ6")]
-    #[case("ABCJ6", "ABC", FuturesMonth::April, 2026, "ABCJ6")]
+    #[case("RTYM6", "RTY", FuturesMonth::June, 2026, "RTYM26")]
+    #[case("6EZ6", "6E", FuturesMonth::December, 2026, "6EZ26")]
+    #[case("ABCJ6", "ABC", FuturesMonth::April, 2026, "ABCJ26")]
     fn parses_supported_raw_contracts(
         #[case] raw: &str,
         #[case] root: &str,
@@ -73,8 +73,8 @@ mod tests {
     fn contract_enum_exposes_raw_symbol() {
         let contract = Contract::from_raw_symbol("CLK6").unwrap();
 
-        assert_eq!(contract.raw_symbol(), "CLK6");
-        assert_eq!(contract.to_string(), "CLK6");
+        assert_eq!(contract.raw_symbol(), "CLK26");
+        assert_eq!(contract.to_string(), "CLK26");
     }
 
     #[test]

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -10,7 +10,7 @@ pub use types::{Contract, FuturesContract, FuturesMonth, FuturesRoot};
 
 #[cfg(test)]
 mod tests {
-    use chrono::NaiveDate;
+    use chrono::{Datelike, NaiveDate};
     use rstest::rstest;
 
     use super::*;
@@ -39,9 +39,12 @@ mod tests {
     #[test]
     fn one_digit_year_normalizes_to_current_or_next_decade() {
         let contract = FuturesContractBuilder::raw("CLZ5").build().unwrap();
+        let current_year =
+            u16::try_from(chrono::Utc::now().date_naive().year()).expect("year fits in u16");
 
-        assert_eq!(contract.year, 2035);
-        assert_eq!(contract.to_string(), "CLZ35");
+        assert_eq!(contract.year % 10, 5);
+        assert!(contract.year >= current_year);
+        assert!(contract.year < current_year + 10);
     }
 
     #[rstest]
@@ -75,6 +78,13 @@ mod tests {
         assert_eq!(contract.month, FuturesMonth::June);
         assert_eq!(contract.year, 2026);
         assert_eq!(contract.raw_symbol(), "GCM26");
+    }
+
+    #[test]
+    fn activ_parser_rejects_invalid_month_code() {
+        let error = FuturesContractBuilder::activ("GC/26A").unwrap_err();
+
+        assert_eq!(error, FuturesContractParseError::InvalidMonthCode('A'));
     }
 
     #[test]

--- a/src/contract/proto.rs
+++ b/src/contract/proto.rs
@@ -1,4 +1,4 @@
-use super::{Contract, FuturesContract, FuturesMonth, FuturesRoot, YearFormat};
+use super::{Contract, FuturesContract, FuturesMonth, FuturesRoot};
 
 impl Contract {
     pub(crate) fn to_proto(self) -> crate::schema::Contract {
@@ -25,7 +25,6 @@ impl FuturesContract {
             root: self.root.cme_code().to_string(),
             month: self.month.to_proto_i32(),
             year: u32::from(self.year),
-            year_format: self.year_format.to_proto_i32(),
         }
     }
 
@@ -35,33 +34,8 @@ impl FuturesContract {
         let month = FuturesMonth::from_proto_i32(proto.month)?;
         let year = u16::try_from(proto.year)
             .map_err(|_| prost::DecodeError::new("Invalid futures contract year"))?;
-        let year_format = YearFormat::from_proto_i32(proto.year_format)?;
 
-        Ok(Self {
-            root,
-            month,
-            year,
-            year_format,
-        })
-    }
-}
-
-impl YearFormat {
-    fn to_proto_i32(self) -> i32 {
-        match self {
-            Self::OneDigit => 1,
-            Self::TwoDigit => 2,
-        }
-    }
-
-    fn from_proto_i32(value: i32) -> Result<Self, prost::DecodeError> {
-        match value {
-            1 => Ok(Self::OneDigit),
-            2 => Ok(Self::TwoDigit),
-            _ => Err(prost::DecodeError::new(format!(
-                "Invalid futures year format value: {value}",
-            ))),
-        }
+        Ok(Self { root, month, year })
     }
 }
 

--- a/src/contract/proto.rs
+++ b/src/contract/proto.rs
@@ -1,0 +1,92 @@
+use super::{Contract, FuturesContract, FuturesMonth, FuturesRoot, YearFormat};
+
+impl Contract {
+    pub(crate) fn to_proto(self) -> crate::schema::Contract {
+        match self {
+            Self::Futures(contract) => crate::schema::Contract {
+                value: Some(crate::schema::contract::Value::Futures(contract.to_proto())),
+            },
+        }
+    }
+
+    pub(crate) fn from_proto(proto: crate::schema::Contract) -> Result<Self, prost::DecodeError> {
+        match proto.value {
+            Some(crate::schema::contract::Value::Futures(contract)) => {
+                Ok(Self::Futures(FuturesContract::from_proto(contract)?))
+            }
+            None => Err(prost::DecodeError::new("Missing contract variant")),
+        }
+    }
+}
+
+impl FuturesContract {
+    fn to_proto(self) -> crate::schema::FuturesContract {
+        crate::schema::FuturesContract {
+            root: self.root.cme_code().to_string(),
+            month: self.month.to_proto_i32(),
+            year: u32::from(self.year),
+            year_format: self.year_format.to_proto_i32(),
+        }
+    }
+
+    fn from_proto(proto: crate::schema::FuturesContract) -> Result<Self, prost::DecodeError> {
+        let root = FuturesRoot::new(&proto.root)
+            .map_err(|err| prost::DecodeError::new(err.to_string()))?;
+        let month = FuturesMonth::from_proto_i32(proto.month)?;
+        let year = u16::try_from(proto.year)
+            .map_err(|_| prost::DecodeError::new("Invalid futures contract year"))?;
+        let year_format = YearFormat::from_proto_i32(proto.year_format)?;
+
+        Ok(Self {
+            root,
+            month,
+            year,
+            year_format,
+        })
+    }
+}
+
+impl YearFormat {
+    fn to_proto_i32(self) -> i32 {
+        match self {
+            Self::OneDigit => 1,
+            Self::TwoDigit => 2,
+        }
+    }
+
+    fn from_proto_i32(value: i32) -> Result<Self, prost::DecodeError> {
+        match value {
+            1 => Ok(Self::OneDigit),
+            2 => Ok(Self::TwoDigit),
+            _ => Err(prost::DecodeError::new(format!(
+                "Invalid futures year format value: {value}",
+            ))),
+        }
+    }
+}
+
+impl FuturesMonth {
+    fn to_proto_i32(self) -> i32 {
+        i32::from(self.number())
+    }
+
+    fn from_proto_i32(value: i32) -> Result<Self, prost::DecodeError> {
+        match value {
+            1 => Ok(Self::January),
+            2 => Ok(Self::February),
+            3 => Ok(Self::March),
+            4 => Ok(Self::April),
+            5 => Ok(Self::May),
+            6 => Ok(Self::June),
+            7 => Ok(Self::July),
+            8 => Ok(Self::August),
+            9 => Ok(Self::September),
+            10 => Ok(Self::October),
+            11 => Ok(Self::November),
+            12 => Ok(Self::December),
+            _ => Err(prost::DecodeError::new(format!(
+                "Invalid futures month value: {value}",
+            ))),
+        }
+    }
+}

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -76,21 +76,15 @@ pub struct FuturesContract {
     pub root: FuturesRoot,
     pub month: FuturesMonth,
     pub year: u16,
-    pub year_format: YearFormat,
 }
 
 impl FuturesContract {
     pub fn raw_symbol(&self) -> String {
-        let year_suffix = match self.year_format {
-            YearFormat::OneDigit => format!("{}", self.year % 10),
-            YearFormat::TwoDigit => format!("{:02}", self.year % 100),
-        };
-
         format!(
-            "{}{}{}",
+            "{}{}{:02}",
             self.root.cme_code(),
             self.month.code(),
-            year_suffix
+            self.year % 100
         )
     }
 
@@ -195,18 +189,6 @@ impl<'de> serde::Deserialize<'de> for FuturesRoot {
         let root = <String as serde::Deserialize>::deserialize(deserializer)?;
         Self::new(&root).map_err(serde::de::Error::custom)
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "borsh",
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub enum YearFormat {
-    OneDigit,
-    TwoDigit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -40,6 +40,12 @@ impl Contract {
         }
     }
 
+    pub fn contract_month_yyyymm(&self) -> String {
+        match self {
+            Self::Futures(contract) => contract.contract_month_yyyymm(),
+        }
+    }
+
     pub fn validate_against_date(
         &self,
         date: chrono::NaiveDate,
@@ -86,6 +92,10 @@ impl FuturesContract {
             self.month.code(),
             self.year % 100
         )
+    }
+
+    pub fn contract_month_yyyymm(&self) -> String {
+        format!("{}{:02}", self.year, self.month.number())
     }
 
     pub fn validate_against_date(
@@ -249,7 +259,7 @@ impl FuturesMonth {
         }
     }
 
-    pub(super) fn number(self) -> u8 {
+    pub const fn number(self) -> u8 {
         match self {
             Self::January => 1,
             Self::February => 2,

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -1,0 +1,300 @@
+use std::fmt;
+
+use chrono::Datelike;
+
+use super::{FuturesContractBuilder, FuturesContractParseError};
+
+const MAX_MONTHS_IN_PAST: i32 = 0;
+const MAX_MONTHS_IN_FUTURE: i32 = 12;
+const MAX_FUTURES_ROOT_LEN: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub enum Contract {
+    Futures(FuturesContract),
+}
+
+impl Contract {
+    pub fn from_raw_symbol(symbol: &str) -> Result<Self, FuturesContractParseError> {
+        FuturesContractBuilder::raw(symbol)
+            .build()
+            .map(Contract::Futures)
+    }
+
+    pub fn from_cme_symbol(symbol: &str) -> Result<Self, FuturesContractParseError> {
+        Self::from_raw_symbol(symbol)
+    }
+
+    pub fn from_activ_symbol(symbol: &str) -> Result<Self, FuturesContractParseError> {
+        FuturesContractBuilder::activ(symbol).map(Contract::Futures)
+    }
+
+    pub fn raw_symbol(&self) -> String {
+        match self {
+            Self::Futures(contract) => contract.raw_symbol(),
+        }
+    }
+
+    pub fn validate_against_date(
+        &self,
+        date: chrono::NaiveDate,
+    ) -> Result<(), FuturesContractParseError> {
+        match self {
+            Self::Futures(contract) => contract.validate_against_date(date),
+        }
+    }
+}
+
+impl fmt::Display for Contract {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.raw_symbol())
+    }
+}
+
+impl std::str::FromStr for Contract {
+    type Err = FuturesContractParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_raw_symbol(s)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct FuturesContract {
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
+    pub root: FuturesRoot,
+    pub month: FuturesMonth,
+    pub year: u16,
+    pub year_format: YearFormat,
+}
+
+impl FuturesContract {
+    pub fn raw_symbol(&self) -> String {
+        let year_suffix = match self.year_format {
+            YearFormat::OneDigit => format!("{}", self.year % 10),
+            YearFormat::TwoDigit => format!("{:02}", self.year % 100),
+        };
+
+        format!(
+            "{}{}{}",
+            self.root.cme_code(),
+            self.month.code(),
+            year_suffix
+        )
+    }
+
+    pub fn validate_against_date(
+        &self,
+        date: chrono::NaiveDate,
+    ) -> Result<(), FuturesContractParseError> {
+        let contract_month_index = contract_month_index(self.year, self.month);
+        let reference_month_index = date_month_index(date);
+        let months_from_reference = contract_month_index - reference_month_index;
+
+        if months_from_reference < -MAX_MONTHS_IN_PAST {
+            return Err(FuturesContractParseError::TooFarInPast {
+                contract: self.raw_symbol(),
+                reference_date: date.to_string(),
+            });
+        }
+
+        if months_from_reference > MAX_MONTHS_IN_FUTURE {
+            return Err(FuturesContractParseError::TooFarInFuture {
+                contract: self.raw_symbol(),
+                reference_date: date.to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for FuturesContract {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.raw_symbol())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct FuturesRoot {
+    len: u8,
+    bytes: [u8; MAX_FUTURES_ROOT_LEN],
+}
+
+impl FuturesRoot {
+    pub fn new(root: &str) -> Result<Self, FuturesContractParseError> {
+        let normalized = root.trim().to_ascii_uppercase();
+        if normalized.is_empty()
+            || normalized.len() > MAX_FUTURES_ROOT_LEN
+            || !normalized.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        {
+            return Err(FuturesContractParseError::InvalidRoot(root.to_string()));
+        }
+
+        let mut bytes = [0; MAX_FUTURES_ROOT_LEN];
+        bytes[..normalized.len()].copy_from_slice(normalized.as_bytes());
+
+        Ok(Self {
+            len: u8::try_from(normalized.len()).expect("MAX_FUTURES_ROOT_LEN must fit in u8"),
+            bytes,
+        })
+    }
+
+    pub fn cme_code(&self) -> &str {
+        std::str::from_utf8(&self.bytes[..usize::from(self.len)])
+            .expect("FuturesRoot is validated as ASCII")
+    }
+}
+
+impl fmt::Display for FuturesRoot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.cme_code())
+    }
+}
+
+impl std::str::FromStr for FuturesRoot {
+    type Err = FuturesContractParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for FuturesRoot {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.cme_code())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for FuturesRoot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let root = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(&root).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub enum YearFormat {
+    OneDigit,
+    TwoDigit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub enum FuturesMonth {
+    January,
+    February,
+    March,
+    April,
+    May,
+    June,
+    July,
+    August,
+    September,
+    October,
+    November,
+    December,
+}
+
+impl FuturesMonth {
+    pub fn code(self) -> char {
+        match self {
+            Self::January => 'F',
+            Self::February => 'G',
+            Self::March => 'H',
+            Self::April => 'J',
+            Self::May => 'K',
+            Self::June => 'M',
+            Self::July => 'N',
+            Self::August => 'Q',
+            Self::September => 'U',
+            Self::October => 'V',
+            Self::November => 'X',
+            Self::December => 'Z',
+        }
+    }
+
+    pub fn from_code(code: char) -> Option<Self> {
+        match code.to_ascii_uppercase() {
+            'F' => Some(Self::January),
+            'G' => Some(Self::February),
+            'H' => Some(Self::March),
+            'J' => Some(Self::April),
+            'K' => Some(Self::May),
+            'M' => Some(Self::June),
+            'N' => Some(Self::July),
+            'Q' => Some(Self::August),
+            'U' => Some(Self::September),
+            'V' => Some(Self::October),
+            'X' => Some(Self::November),
+            'Z' => Some(Self::December),
+            _ => None,
+        }
+    }
+
+    pub(super) fn number(self) -> u8 {
+        match self {
+            Self::January => 1,
+            Self::February => 2,
+            Self::March => 3,
+            Self::April => 4,
+            Self::May => 5,
+            Self::June => 6,
+            Self::July => 7,
+            Self::August => 8,
+            Self::September => 9,
+            Self::October => 10,
+            Self::November => 11,
+            Self::December => 12,
+        }
+    }
+}
+
+impl fmt::Display for FuturesMonth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.code())
+    }
+}
+
+fn contract_month_index(year: u16, month: FuturesMonth) -> i32 {
+    i32::from(year) * 12 + i32::from(month.number())
+}
+
+fn date_month_index(date: chrono::NaiveDate) -> i32 {
+    date.year() * 12 + i32::try_from(date.month()).expect("chrono month must fit in i32")
+}

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -143,7 +143,7 @@ pub struct FuturesRoot {
 
 impl FuturesRoot {
     pub fn new(root: &str) -> Result<Self, FuturesContractParseError> {
-        let normalized = root.trim().to_ascii_uppercase();
+        let normalized = root.trim();
         if normalized.is_empty()
             || normalized.len() > MAX_FUTURES_ROOT_LEN
             || !normalized.bytes().all(|byte| byte.is_ascii_alphanumeric())
@@ -152,7 +152,9 @@ impl FuturesRoot {
         }
 
         let mut bytes = [0; MAX_FUTURES_ROOT_LEN];
-        bytes[..normalized.len()].copy_from_slice(normalized.as_bytes());
+        for (output, input) in bytes.iter_mut().zip(normalized.bytes()) {
+            *output = input.to_ascii_uppercase();
+        }
 
         Ok(Self {
             len: u8::try_from(normalized.len()).expect("MAX_FUTURES_ROOT_LEN must fit in u8"),

--- a/src/entries/global_exposure.rs
+++ b/src/entries/global_exposure.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "proto")]
 use prost::Message;
 
+use crate::contract::Contract;
 #[cfg(feature = "proto")]
 use crate::{ProtoDeserialize, ProtoSerialize};
 
@@ -17,6 +18,7 @@ pub struct GlobalExposureEntry {
     pub asset: String,
     pub gross_position_size: f64,
     pub net_position_size: f64,
+    pub contract: Option<Contract>,
 }
 
 #[cfg(feature = "proto")]
@@ -28,6 +30,7 @@ impl GlobalExposureEntry {
             asset: self.asset.clone(),
             gross_position_size: self.gross_position_size,
             net_position_size: self.net_position_size,
+            contract: self.contract.map(Contract::to_proto),
         }
     }
 
@@ -38,6 +41,7 @@ impl GlobalExposureEntry {
             asset: proto.asset,
             gross_position_size: proto.gross_position_size,
             net_position_size: proto.net_position_size,
+            contract: proto.contract.map(Contract::from_proto).transpose()?,
         })
     }
 }
@@ -59,5 +63,26 @@ impl ProtoDeserialize for GlobalExposureEntry {
     fn from_proto_bytes(bytes: &[u8]) -> Result<Self, prost::DecodeError> {
         let proto = crate::schema::GlobalExposureEntry::decode(bytes)?;
         Self::from_proto(proto)
+    }
+}
+
+#[cfg(all(test, feature = "proto"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proto_roundtrip_preserves_contract() {
+        let entry = GlobalExposureEntry {
+            source: "EXPOSURE_AGGREGATOR".to_string(),
+            timestamp_ms: 1,
+            asset: "WTI".to_string(),
+            gross_position_size: 10.0,
+            net_position_size: -4.0,
+            contract: Some(Contract::from_raw_symbol("CLK6").unwrap()),
+        };
+
+        let decoded = GlobalExposureEntry::from_proto_bytes(&entry.to_proto_bytes()).unwrap();
+
+        assert_eq!(decoded, entry);
     }
 }

--- a/src/entries/position.rs
+++ b/src/entries/position.rs
@@ -1,5 +1,5 @@
 use super::trade::TradeSide;
-use crate::{instrument_type::InstrumentType, pair::Pair};
+use crate::{contract::Contract, instrument_type::InstrumentType, pair::Pair};
 #[cfg(feature = "proto")]
 use crate::{ProtoDeserialize, ProtoSerialize};
 #[cfg(feature = "proto")]
@@ -20,6 +20,7 @@ pub struct PositionEntry {
     pub side: TradeSide,
     pub notional_in_usd: f64,
     pub size: f64,
+    pub contract: Option<Contract>,
 }
 #[cfg(feature = "proto")]
 impl PositionEntry {
@@ -42,6 +43,7 @@ impl PositionEntry {
             },
             notional_in_usd: self.notional_in_usd,
             size: self.size,
+            contract: self.contract.map(Contract::to_proto),
         }
     }
     fn from_proto(proto: crate::schema::PositionEntry) -> Result<Self, prost::DecodeError> {
@@ -83,6 +85,7 @@ impl PositionEntry {
             side,
             notional_in_usd: proto.notional_in_usd,
             size: proto.size,
+            contract: proto.contract.map(Contract::from_proto).transpose()?,
         })
     }
 }

--- a/src/entries/position.rs
+++ b/src/entries/position.rs
@@ -18,7 +18,6 @@ pub struct PositionEntry {
     pub timestamp_ms: i64,
     pub received_timestamp_ms: i64,
     pub side: TradeSide,
-    pub notional_in_usd: f64,
     pub size: f64,
     pub contract: Option<Contract>,
 }
@@ -41,7 +40,6 @@ impl PositionEntry {
                 TradeSide::Buy => crate::schema::TradeSide::Buy as i32,
                 TradeSide::Sell => crate::schema::TradeSide::Sell as i32,
             },
-            notional_in_usd: self.notional_in_usd,
             size: self.size,
             contract: self.contract.map(Contract::to_proto),
         }
@@ -83,7 +81,6 @@ impl PositionEntry {
             timestamp_ms: proto.timestamp_ms,
             received_timestamp_ms: proto.received_timestamp_ms,
             side,
-            notional_in_usd: proto.notional_in_usd,
             size: proto.size,
             contract: proto.contract.map(Contract::from_proto).transpose()?,
         })

--- a/src/entries/price.rs
+++ b/src/entries/price.rs
@@ -22,7 +22,6 @@ pub struct PriceEntry {
     pub received_timestamp_ms: i64,
 }
 
-
 #[cfg(feature = "proto")]
 impl PriceEntry {
     fn to_proto(&self) -> crate::schema::PriceEntry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use pair::{AssetSymbol, Pair, RawMarketName};
 pub mod contract;
 pub use contract::{
     Contract, FuturesContract, FuturesContractBuilder, FuturesContractParseError, FuturesMonth,
-    FuturesRoot, YearFormat,
+    FuturesRoot,
 };
 
 // Exchange

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,13 @@ pub use trading::Side;
 pub mod pair;
 pub use pair::{AssetSymbol, Pair, RawMarketName};
 
+// Contracts
+pub mod contract;
+pub use contract::{
+    Contract, FuturesContract, FuturesContractBuilder, FuturesContractParseError, FuturesMonth,
+    FuturesRoot, YearFormat,
+};
+
 // Exchange
 pub mod exchange;
 pub use exchange::{Exchange, MarginType};

--- a/tests/test_proto.rs
+++ b/tests/test_proto.rs
@@ -3,11 +3,13 @@ use pragma_common::{
     entries::funding_rate::FundingRateEntry,
     entries::open_interest::OpenInterestEntry,
     entries::orderbook::{OrderbookData, OrderbookEntry, OrderbookUpdateType, UpdateType},
+    entries::position::PositionEntry,
     entries::price::PriceEntry,
+    entries::trade::TradeSide,
     entries::volume::VolumeEntry,
     instrument_type::InstrumentType,
     web3::Chain,
-    Pair, ProtoDeserialize, ProtoSerialize,
+    Contract, Pair, ProtoDeserialize, ProtoSerialize,
 };
 
 #[cfg(feature = "proto")]
@@ -138,6 +140,27 @@ fn test_volume_entry_proto() {
     };
     let payload = x.to_proto_bytes();
     let entry: VolumeEntry = VolumeEntry::from_proto_bytes(&payload).unwrap();
+    assert_eq!(entry, x);
+}
+
+#[cfg(feature = "proto")]
+#[test]
+fn test_position_entry_proto_with_contract() {
+    let x = PositionEntry {
+        source: "TEST".to_string(),
+        instrument_type: InstrumentType::Perp,
+        pair: Pair::from_currencies("WTI", "USD"),
+        timestamp_ms: 145567,
+        received_timestamp_ms: 145577,
+        side: TradeSide::Buy,
+        notional_in_usd: 1_000.0,
+        size: 10.0,
+        contract: Some(Contract::from_cme_symbol("CLK6").unwrap()),
+    };
+
+    let payload = x.to_proto_bytes();
+    let entry: PositionEntry = PositionEntry::from_proto_bytes(&payload).unwrap();
+
     assert_eq!(entry, x);
 }
 

--- a/tests/test_proto.rs
+++ b/tests/test_proto.rs
@@ -153,7 +153,6 @@ fn test_position_entry_proto_with_contract() {
         timestamp_ms: 145567,
         received_timestamp_ms: 145577,
         side: TradeSide::Buy,
-        notional_in_usd: 1_000.0,
         size: 10.0,
         contract: Some(Contract::from_cme_symbol("CLK6").unwrap()),
     };


### PR DESCRIPTION
## Summary
- add a typed Contract/FuturesContract model in pragma-common without enumerating futures roots
- add Contract to PositionEntry and GlobalExposureEntry proto serialization/deserialization
- refactor contract parsing into a contract/ module with raw/ACTIV builders
- expose Contract::contract_month_yyyymm() and FuturesMonth::number() for downstream IBKR/DataBento routing without duplicating month mappings
- bump pragma-common to 0.7.0

## Validation
- cargo test
- cargo test --features proto contract::
- cargo test --features proto test_position_entry_proto_with_contract
- cargo +nightly fmt --check
